### PR TITLE
Adding input 'platform' to select linux or macos

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -69,7 +69,7 @@ runs:
       shell: bash
     - name: Downloading Checks CLI version ${{ inputs.version }}
       run: | 
-        echo "Downloading Checks CLI version ${{ inputs.version }}"
+        echo "Downloading Checks CLI version ${{ inputs.version }} for ${{ platform }}"
         curl --compressed https://dl.google.com/checks/cli/${{ inputs.version }}/checks-${{ platform }} -o checks
         chmod +x checks
         ./checks version

--- a/action.yml
+++ b/action.yml
@@ -51,6 +51,10 @@ inputs:
     description: 'Wait for report after uploading binary'
     required: false
     default: true
+  platform:
+    description: 'Specify the operating system for the executable. Valid options are linux or macos.'
+    required: false
+    default: linux    
 runs:
   using: "composite"
   steps:
@@ -66,7 +70,7 @@ runs:
     - name: Downloading Checks CLI version ${{ inputs.version }}
       run: | 
         echo "Downloading Checks CLI version ${{ inputs.version }}"
-        curl --compressed https://dl.google.com/checks/cli/${{ inputs.version }}/checks-linux -o checks
+        curl --compressed https://dl.google.com/checks/cli/${{ inputs.version }}/checks-${{ platform }} -o checks
         chmod +x checks
         ./checks version
       shell: bash


### PR DESCRIPTION
Specify the operating system for the executable. Valid options are linux or macos.

An alternate solution could be to obtain the platform in bash before the download:

# Check if macOS using uname
if [[ $(uname) == "Darwin" ]]; then
  PLATFORM="macos"
else
  PLATFORM="linux"
fi